### PR TITLE
Don't import STATIC_URL in admin module

### DIFF
--- a/timelinejs/admin.py
+++ b/timelinejs/admin.py
@@ -1,6 +1,6 @@
 from django.contrib.admin import site, ModelAdmin, StackedInline
 from timelinejs.models import Timeline, TimelineEvent, TimelineOptions
-from timeline.settings import STATIC_URL
+
 
 class CommonMedia:
     js = (


### PR DESCRIPTION
timeline.settings doesn't exist, so this caused an error when trying to use the app. STATIC_URL should probably be imported from django.conf.settings instead, but since it isn't even used, avoiding the import entirely should suffice.

This fixes #2 in the upstream repo.
