### PR TITLE
Handle timeline PKs that are longs

### DIFF
--- a/timelinejs/templatetags/timeline.py
+++ b/timelinejs/templatetags/timeline.py
@@ -7,13 +7,14 @@ register = template.Library()
 def timeline(context, src=None, **config):
     if src is None:
         src = context['timeline'].pk
-    if isinstance(src, int):
-        config['src'] = '%s?format=json' % reverse('timelineview', kwargs={'pk':src})
-    elif src.isdigit():
-        print 'its a digit ', src
+    if isinstance(src, (int, long)):
         config['src'] = '%s?format=json' % reverse('timelineview', kwargs={'pk':src})
     else:
-        config['src'] = src
+        try:
+            # `src` might be a string that can be coerced into a long
+            config['src'] = '%s?format=json' % reverse('timelineview', kwargs={'pk': long(src)})
+        except ValueError:
+            config['src'] = src
     if context.has_key('options'):
         options = context['options']
         options.__dict__.update(config)


### PR DESCRIPTION
If a `src` is not specified when calling the `timeline` tag, `timeline` takes the pk of the variable `timeline` in the current context. This is generally a long (not an int), but the tag was only handling ints. This caused an exception in the fallback case, in which it was assumed that `src` had an `isdigit()` method (probably assuming that `src` would be a `str` if it was not an `int`).

This commit handles cases in which `src` is a long (perhaps the most common case), and falls back on converting a string to a long when necessary.
