### PR TITLE
bugfix: fixed typo of timelineoptions start_zoom_adjust

### DIFF
--- a/timelinejs/templates/timeline_template.html
+++ b/timelinejs/templates/timeline_template.html
@@ -13,7 +13,7 @@
                         embed_id:           '{{ config.embed_id|default:"timeline-embed" }}',              
                         start_at_end:       {{ config.start_at_end|lower|default:'false' }},                          
                         start_at_slide:     '{{ config.start_at_slide|default:0 }}',
-                        start_zoom_adjust:  '{{ config.start_zoom|default:0 }}',                            
+                        start_zoom_adjust:  '{{ config.start_zoom_adjust|default:0 }}',                            
                         hash_bookmark:      {{ config.bookmark|lower|default:'false' }},                           
                         font:               '{{ config.font|default:"Bevan-PotanoSans" }}',             
                         debug:              {{ config.debug|lower|default:'false' }},                         


### PR DESCRIPTION
Changed from config.start_zoom to config.start_zoom_adjust so that it'll pick up start zoom level.
